### PR TITLE
fix: handle null sessions case in anvilwebgw

### DIFF
--- a/cmd/anvilwebgw/main.go
+++ b/cmd/anvilwebgw/main.go
@@ -312,7 +312,7 @@ func listSessions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var sessions []Session
+	sessions := []Session{}
 	for _, line := range strings.Split(string(data), "\n") {
 		if line == "" {
 			continue


### PR DESCRIPTION
Fixes the JavaScript error when no sessions are running.

**Problem:**
When no sessions exist, the Go backend returned  for the sessions array, causing JavaScript to fail with: `can't access property Symbol.iterator, sessions is null`

**Solution:**
Initialize the sessions slice as an empty array (`[]Session{}`) instead of nil (`var sessions []Session`). This ensures JSON encoding returns `[]` instead of `null`, which JavaScript can properly iterate over.

**Changes:**
- `cmd/anvilwebgw/main.go`: Changed session slice initialization