### PR TITLE
Add approval gates: beads schema, Conductor, notification daemon, init scripts

### DIFF
--- a/BEADS.md
+++ b/BEADS.md
@@ -16,6 +16,7 @@ agent/beads/
 ├── query                  # Filtered query endpoint (write JSON filter, read results)
 ├── list                   # All beads (JSON)
 ├── ready                  # Ready beads (no blockers, JSON)
+├── pending                # Beads awaiting human approval/review (JSON)
 ├── stats                  # Statistics (JSON)
 ├── blocked                # Blocked issues (JSON)
 ├── stale                  # Stale issues (not updated in 30+ days, JSON)
@@ -26,7 +27,7 @@ agent/beads/
 ├── label/<label>          # Issues with label (JSON)
 ├── children/<id>          # Direct children of parent (JSON)
 └── <bead-id>/
-    ├── status             # open | in_progress | closed
+    ├── status             # open | in_progress | pending_approval | pending_review | closed
     ├── title              # Bead title
     ├── description        # Bead description
     ├── assignee           # Assigned actor
@@ -56,6 +57,9 @@ agent/beads/
 | `comment` | `comment <bead-id> 'text'` | Add comment to bead |
 | `label` | `label <bead-id> 'label'` | Add label to bead |
 | `unlabel` | `unlabel <bead-id> 'label'` | Remove label from bead |
+| `pending-approval` | `pending-approval <bead-id> [assignee]` | Set status=pending_approval and assignee (default: user) |
+| `pending-review` | `pending-review <bead-id> [assignee]` | Set status=pending_review and assignee (default: user) |
+| `resume` | `resume <bead-id> [assignee]` | Set status=in_progress and assignee after approval (default: user) |
 
 ## Usage Examples
 
@@ -168,6 +172,70 @@ Available filter fields:
 - `priority` (int): Filter by priority (1-5)
 - `labels` (array): Filter by labels (all must match)
 - `parent_id` (string): Filter by parent ID
+
+## Approval Gates (Human in the Loop)
+
+Approval gates allow bots to pause work and request human sign-off before proceeding with critical or irreversible operations.
+
+### Status Values
+
+Two statuses mark beads awaiting a human response:
+
+| Status | Description |
+|--------|-------------|
+| `pending_approval` | Bot sent `APPROVAL_REQUEST`; waiting for human `APPROVAL_RESPONSE` |
+| `pending_review` | Bot sent `REVIEW_REQUEST`; waiting for human `REVIEW_RESPONSE` |
+
+Beads in either status are **not** surfaced by `agent/beads/ready` — bots will not accidentally claim them. Use `agent/beads/pending` to list all beads awaiting human input.
+
+### Label Conventions
+
+Add these labels to beads that should trigger a human gate at completion:
+
+| Label | Meaning |
+|-------|---------|
+| `requires_approval` | Completion requires an `APPROVAL_REQUEST`/`APPROVAL_RESPONSE` exchange |
+| `requires_review` | Completion requires a `REVIEW_REQUEST`/`REVIEW_RESPONSE` exchange |
+
+Example: `echo "label bd-abc requires_approval" | 9p write agent/beads/ctl`
+
+### Approval Workflow
+
+```sh
+# 1. Bot sends approval request to user
+#    (via anvillm-communication skill or send_message MCP tool)
+#    type: APPROVAL_REQUEST
+#    subject: "Approve: delete production database backup?"
+#    body:    "I am about to run: DROP TABLE backups. Reason: cleanup task bd-xyz. Approve?"
+
+# 2. Bot atomically marks bead pending and assigns to user for review
+echo "pending-approval bd-xyz" | 9p write agent/beads/ctl
+# (optionally assign to a specific agent: "pending-approval bd-xyz agent-id")
+
+# 3. Human reviews in their inbox (Assist, anvilweb, TUI, or Emacs)
+#    and clicks Approve or Reject
+
+# 4a. On APPROVAL_RESPONSE (approved) — bot resumes and reassigns to itself:
+echo "resume bd-xyz $AGENT_ID" | 9p write agent/beads/ctl
+# ... continue work ...
+echo "complete bd-xyz" | 9p write agent/beads/ctl
+
+# 4b. On APPROVAL_RESPONSE (rejected) — bot stops:
+echo "fail bd-xyz 'human rejected: too risky'" | 9p write agent/beads/ctl
+```
+
+### Monitoring Pending Approvals
+
+```sh
+# List all beads awaiting human input
+9p read agent/beads/pending | jq .
+
+# Filter only approval-pending
+9p read agent/beads/pending | jq '[.[] | select(.status == "pending_approval")]'
+
+# Filter only review-pending
+9p read agent/beads/pending | jq '[.[] | select(.status == "pending_review")]'
+```
 
 ## Initialization
 

--- a/bot-templates/Conductor
+++ b/bot-templates/Conductor
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Conductor - Orchestration bot that manages other bots and routes tasks
-# Usage: ./bot-templates/Conductor <backend> <workdir>
+# Usage: ./bot-templates/Conductor <backend> <workdir> [< custom-prompt.txt]
+#
+# The context prompt is read from stdin when stdin is not a terminal,
+# letting users supply a customized prompt file without editing this script.
+# Example:
+#   ./bot-templates/Conductor claude /path/to/project < my-conductor-prompt.txt
+#
+# When stdin is a terminal (interactive), the built-in default prompt is used.
 
 set -e
 
@@ -29,7 +36,10 @@ CONDUCTOR_ID=$(9p read $AGENT_MOUNT/list | head -1 | awk '{print $1}')
 
 echo "$ALIAS_NAME" | 9p write $AGENT_MOUNT/$CONDUCTOR_ID/alias
 
-cat <<EOF | 9p write $AGENT_MOUNT/$CONDUCTOR_ID/context
+# Determine prompt source: stdin (piped file) or built-in default.
+if [ -t 0 ]; then
+    # stdin is a terminal — use the built-in default prompt.
+    CONTEXT=$(cat <<EOF
 You are the Conductor - an orchestration bot that DELEGATES work to other bots.
 
 CRITICAL: You DO NOT implement solutions, write code, or do the work yourself. Your ONLY job is to DELEGATE to specialized bots.
@@ -42,7 +52,7 @@ Workflow:
 3. Read its child beads using "9p read agent/beads/children/<parent-id>"
 4. For each child bead, start a specialized bot and tell it to claim and work on that child
 5. Bots will send completion messages to your inbox when done (messages arrive automatically)
-6. When a bot notifies you it's done, acknowledge and shut down that bot
+6. When a bot notifies you it's done, kill it: echo "kill" | 9p write agent/<bot-id>/ctl
 7. Check if ALL children are complete by reading "9p read agent/beads/children/<parent-id> | jq 'all(.status == \"closed\")'"
 8. Only mark the parent bead complete when all children have status==closed
 
@@ -51,16 +61,83 @@ Core skills: beads, anvillm-communication
 When creating a bot:
 1. Start the session: echo "new <backend> <workdir>" | 9p write agent/ctl
 2. Get the bot's session ID from agent/list
-3. Write context to agent/<bot-id>/context that includes:
+3. Set a descriptive alias (max 16 characters): echo "<alias>" | 9p write agent/<bot-id>/alias
+   Derive the alias from the bot's role and bead ID, e.g. "dev-i4h.1", "review-i4h",
+   "plan-abc.3". Truncate to 16 characters if needed.
+4. Write context to agent/<bot-id>/context that includes:
    - The bot's role and task
    - Instructions to send completion messages to you (your AGENT_ID is $CONDUCTOR_ID)
    - Instructions to send clarification requests to you when blocked
-   - Example: "When done, send PROMPT_RESPONSE to $CONDUCTOR_ID. If you need clarification, send QUERY_REQUEST to $CONDUCTOR_ID."
+   - Instructions to report failures and rejected approvals to you
+   - Example:
+       "When done: call complete on your bead, then send PROMPT_RESPONSE to $CONDUCTOR_ID.
+        If you need clarification: send QUERY_REQUEST to $CONDUCTOR_ID.
+        If your work fails or is rejected: call fail on your bead with the reason, then send
+        PROMPT_RESPONSE to $CONDUCTOR_ID describing what failed and why."
 
 Message routing:
 - When a bot needs clarification, forward the query to the user with type QUERY_REQUEST
 - When the user responds, relay the answer back to the bot
+- When a bot reports failure, choose based on the reason:
+    RETRY   — transient or recoverable failure (timeout, rate limit, bot got confused/stuck,
+              tool temporarily unavailable). Spawn a fresh bot for the same bead.
+    ESCALATE — failure requires human judgment. ALWAYS escalate on a rejected approval or
+              review: the human may want to adjust the task, relax the constraint, or give
+              you different instructions — do not treat rejection as a hard abort.
+              Also escalate for: ambiguous blocker, missing credentials or access, task
+              definition needs clarification, or repeated retries have not helped.
+              Send QUERY_REQUEST to the user describing what failed and asking how to proceed.
+    FAIL    — work is definitively uncompletable without replanning: a required dependency
+              cannot be satisfied, the user has directed you to abort, or escalation produced
+              no resolution. Call fail on the parent bead.
+
+## Approval Gates (Human in the Loop)
+
+Some actions REQUIRE human approval before proceeding. These are actions that are
+irreversible, destructive, high-risk, or have been explicitly flagged requires_approval.
+
+### Actions That Require Approval
+
+Before performing any of the following, send an APPROVAL_REQUEST to the user and
+wait for an APPROVAL_RESPONSE:
+
+- Deleting beads or significant work items
+- Spawning more than 5 sub-agents simultaneously
+- Any action on beads labeled "requires_approval" or "requires_review"
+- Destructive file system operations (deleting source files, truncating databases)
+- Publishing or deploying code to production systems
+- Any operation the user has explicitly flagged as requiring review
+
+### Approval Workflow
+
+1. Send APPROVAL_REQUEST to user ("user") via mailbox with:
+   - subject: brief summary of the action requiring approval
+   - body: full description of what will happen, the risk, and why you want to proceed
+
+2. Atomically mark the bead pending and assign it to the user for review:
+   echo "pending-approval <bead-id>" | 9p write agent/beads/ctl
+
+3. Wait for the user's APPROVAL_RESPONSE in your inbox (check periodically with read_inbox).
+
+4. On approval: resume the bead and reassign it back to yourself:
+   echo "resume <bead-id> $CONDUCTOR_ID" | 9p write agent/beads/ctl
+
+5. On rejection: fail the bead with the rejection reason:
+   echo "fail <bead-id> 'human rejected: <reason>'" | 9p write agent/beads/ctl
+
+### Timeout Handling
+
+If no APPROVAL_RESPONSE arrives after a reasonable wait (suggest checking 3-5 times
+over ~10 minutes), send a QUERY_REQUEST to the user asking if they saw the approval
+request. Do NOT proceed without approval for any action in the list above.
 EOF
+)
+else
+    # stdin is not a terminal — read custom prompt from stdin.
+    CONTEXT=$(cat)
+fi
+
+printf '%s' "$CONTEXT" | 9p write $AGENT_MOUNT/$CONDUCTOR_ID/context
 
 echo ""
 echo "✓ Conductor workflow ready"

--- a/bot-templates/Taskmaster
+++ b/bot-templates/Taskmaster
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Taskmaster - Task management agent workflow
-# Usage: ./bot-templates/Taskmaster <backend> <workdir>
+# Usage: ./bot-templates/Taskmaster <backend> <workdir> [< custom-prompt.txt]
+#
+# The context prompt is read from stdin when stdin is not a terminal,
+# letting users supply a customized prompt file without editing this script.
+# Example:
+#   ./bot-templates/Taskmaster claude /path/to/project < my-taskmaster-prompt.txt
+#
+# When stdin is a terminal (interactive), the built-in default prompt is used.
 
 set -e
 
@@ -29,11 +36,62 @@ TASKMASTER_ID=$(9p read $AGENT_MOUNT/list | head -1 | awk '{print $1}')
 
 echo "$ALIAS_NAME" | 9p write $AGENT_MOUNT/$TASKMASTER_ID/alias
 
-cat <<EOF | 9p write $AGENT_MOUNT/$TASKMASTER_ID/context
+# Determine prompt source: stdin (piped file) or built-in default.
+if [ -t 0 ]; then
+    # stdin is a terminal — use the built-in default prompt.
+    CONTEXT=$(cat <<'EOF'
 You are a task management specialist. Do not implement solutions or write code. Core skills: beads, anvillm-communication.
 
 You create and update tasks based on requirements using the beads skill, and pull context from Jira, GitHub, web search, or agent-kb to enrich details. You maintain clear descriptions and link sources.
+
+## Approval and Review Labels
+
+When creating or enriching a bead, assess the nature of the work and apply the
+appropriate label if the task meets the criteria below. Use your judgment — not
+every task needs a label, but high-risk or output-sensitive work should always
+be flagged so the Conductor and its agents gate correctly.
+
+### requires_approval
+
+Apply when completing the task would result in an action that is irreversible,
+destructive, or carries significant operational risk. Examples:
+
+- Deleting or truncating data, files, or databases
+- Deploying or publishing to production systems
+- Changes to security settings, access controls, or credentials
+- Large-scale automated changes that are hard to roll back
+- Any action that spends money or triggers external billing
+- Modifications to shared infrastructure or configuration
+
+Command: echo "label <bead-id> requires_approval" | 9p write agent/beads/ctl
+
+### requires_review
+
+Apply when the work produces output that a human should inspect and accept
+before it is considered done, even if the action itself is not destructive.
+Examples:
+
+- Code changes to critical or security-sensitive paths
+- Public-facing content, documentation, or communications
+- Architectural or schema decisions
+- Changes to bot prompts, skills, or orchestration logic
+- Any task where correctness cannot be verified automatically
+
+Command: echo "label <bead-id> requires_review" | 9p write agent/beads/ctl
+
+### Both labels
+
+A task may carry both labels — for example, a database migration that produces
+a migration script (requires_review) and then runs it in production
+(requires_approval).
 EOF
+)
+else
+    # stdin is not a terminal — read custom prompt from stdin.
+    CONTEXT=$(cat)
+fi
+
+printf '%s' "$CONTEXT" | 9p write $AGENT_MOUNT/$TASKMASTER_ID/context
 
 echo ""
 echo "✓ Taskmaster workflow ready"

--- a/internal/p9/beads.go
+++ b/internal/p9/beads.go
@@ -12,6 +12,24 @@ import (
 	bd "github.com/steveyegge/beads"
 )
 
+// Approval gate statuses extend the beads status set locally.
+// These statuses are not surfaced by GetReadyWork (which only returns
+// open/in_progress), ensuring bots do not claim work that is pending
+// human approval or review.
+const (
+	StatusPendingApproval = bd.Status("pending_approval") // Awaiting APPROVAL_RESPONSE from human
+	StatusPendingReview   = bd.Status("pending_review")   // Awaiting REVIEW_RESPONSE from human
+)
+
+// requiresApprovalLabel and requiresReviewLabel are label conventions for
+// marking beads that must pass through a human gate before they can be closed.
+// Agents should send an APPROVAL_REQUEST (or REVIEW_REQUEST) to the user and
+// call `pending-approval <id>` (or `pending-review <id>`) before completing.
+const (
+	requiresApprovalLabel = "requires_approval"
+	requiresReviewLabel   = "requires_review"
+)
+
 // BeadsFS handles beads filesystem operations.
 type BeadsFS struct {
 	store       bd.Storage
@@ -39,6 +57,8 @@ func (b *BeadsFS) Read(path string) ([]byte, error) {
 		return b.readList()
 	case len(parts) == 1 && parts[0] == "ready":
 		return b.readReady("")
+	case len(parts) == 1 && parts[0] == "pending":
+		return b.readPending()
 	case len(parts) == 1 && parts[0] == "stats":
 		return b.readStats()
 	case len(parts) == 1 && parts[0] == "blocked":
@@ -178,6 +198,22 @@ func (b *BeadsFS) readBlocked() ([]byte, error) {
 		return nil, err
 	}
 	return json.MarshalIndent(blocked, "", "  ")
+}
+
+// readPending returns beads in pending_approval or pending_review status,
+// i.e. those awaiting a human APPROVAL_RESPONSE or REVIEW_RESPONSE.
+func (b *BeadsFS) readPending() ([]byte, error) {
+	issues, err := b.store.SearchIssues(b.ctx, "", bd.IssueFilter{})
+	if err != nil {
+		return nil, err
+	}
+	var pending []*bd.Issue
+	for _, issue := range issues {
+		if issue.Status == StatusPendingApproval || issue.Status == StatusPendingReview {
+			pending = append(pending, issue)
+		}
+	}
+	return json.MarshalIndent(pending, "", "  ")
 }
 
 func (b *BeadsFS) readDependenciesMeta(beadID string) ([]byte, error) {
@@ -391,13 +427,19 @@ func (b *BeadsFS) executeCtl(cmd string) error {
 		if len(args) < 1 {
 			return fmt.Errorf("usage: complete <bead-id>")
 		}
-		return b.store.CloseIssue(b.ctx, args[0], "completed", actor, "")
-		
+		if err := b.store.CloseIssue(b.ctx, args[0], "completed", actor, ""); err != nil {
+			return err
+		}
+		return b.store.UpdateIssue(b.ctx, args[0], map[string]interface{}{"assignee": ""}, actor)
+
 	case "fail":
 		if len(args) < 2 {
 			return fmt.Errorf("usage: fail <bead-id> 'reason'")
 		}
-		return b.store.CloseIssue(b.ctx, args[0], args[1], actor, "")
+		if err := b.store.CloseIssue(b.ctx, args[0], args[1], actor, ""); err != nil {
+			return err
+		}
+		return b.store.UpdateIssue(b.ctx, args[0], map[string]interface{}{"assignee": ""}, actor)
 		
 	case "dep", "add-dep":
 		if len(args) < 2 {
@@ -459,9 +501,74 @@ func (b *BeadsFS) executeCtl(cmd string) error {
 			return fmt.Errorf("invalid JSON: %w", err)
 		}
 		return b.store.CreateIssues(b.ctx, issues, actor)
-		
+
+	// Approval gate commands.
+	// Bots should call these after sending an APPROVAL_REQUEST or REVIEW_REQUEST
+	// to the user.  The human responds via the inbox UI; on approve/reject the
+	// bot calls "resume" or "fail" to continue or abort work.
+
+	case "pending-approval":
+		// Atomically set status=pending_approval and assignee (defaults to "user").
+		// Usage: pending-approval <bead-id> [assignee]
+		// Canonical workflow:
+		//   1. Bot sends APPROVAL_REQUEST to user mailbox
+		//   2. Bot calls: echo "pending-approval <id>" | 9p write agent/beads/ctl
+		//   3. Human approves → bot calls: echo "resume <id> <bot-id>" | 9p write agent/beads/ctl
+		//   4. Human rejects → bot calls: echo "fail <id> 'rejected'" | 9p write agent/beads/ctl
+		if len(args) < 1 {
+			return fmt.Errorf("usage: pending-approval <bead-id> [assignee]")
+		}
+		assignee := "user"
+		if len(args) > 1 {
+			assignee = args[1]
+		}
+		updates := map[string]interface{}{
+			"status":   StatusPendingApproval,
+			"assignee": assignee,
+		}
+		return b.store.UpdateIssue(b.ctx, args[0], updates, actor)
+
+	case "pending-review":
+		// Atomically set status=pending_review and assignee (defaults to "user").
+		// Usage: pending-review <bead-id> [assignee]
+		// Canonical workflow:
+		//   1. Bot sends REVIEW_REQUEST to user mailbox
+		//   2. Bot calls: echo "pending-review <id>" | 9p write agent/beads/ctl
+		//   3. Human responds → bot calls: echo "resume <id> <bot-id>" | 9p write agent/beads/ctl
+		//   4. Human rejects → bot calls: echo "fail <id> 'review failed'" | 9p write agent/beads/ctl
+		if len(args) < 1 {
+			return fmt.Errorf("usage: pending-review <bead-id> [assignee]")
+		}
+		assignee := "user"
+		if len(args) > 1 {
+			assignee = args[1]
+		}
+		updates := map[string]interface{}{
+			"status":   StatusPendingReview,
+			"assignee": assignee,
+		}
+		return b.store.UpdateIssue(b.ctx, args[0], updates, actor)
+
+	case "resume":
+		// Atomically set status=in_progress and assignee after human approval/review.
+		// Usage: resume <bead-id> [assignee]
+		// Assignee defaults to "user"; pass the bot's agent ID to hand work back to a bot.
+		// Use "fail" instead if the human rejected.
+		if len(args) < 1 {
+			return fmt.Errorf("usage: resume <bead-id> [assignee]")
+		}
+		assignee := "user"
+		if len(args) > 1 {
+			assignee = args[1]
+		}
+		updates := map[string]interface{}{
+			"status":   bd.StatusInProgress,
+			"assignee": assignee,
+		}
+		return b.store.UpdateIssue(b.ctx, args[0], updates, actor)
+
 	default:
-		return fmt.Errorf("unknown command: %s (supported: init, new, update, delete, claim, complete, fail, dep, undep)", command)
+		return fmt.Errorf("unknown command: %s (supported: init, new, update, delete, claim, complete, fail, dep, undep, pending-approval, pending-review, resume)", command)
 	}
 }
 

--- a/scripts/anvillm-inbox-notify
+++ b/scripts/anvillm-inbox-notify
@@ -1,0 +1,152 @@
+#!/bin/bash
+# anvillm-inbox-notify — Desktop notification daemon for AnviLLM inbox messages.
+#
+# Monitors the AnviLLM event stream for incoming messages addressed to the human
+# user and fires desktop notifications for configurable message types.
+#
+# Usage:
+#   anvillm-inbox-notify [--help]
+#
+# Configuration (~/.config/anvillm/notifications.yaml):
+#   notify_on:
+#     - APPROVAL_REQUEST
+#     - REVIEW_REQUEST
+#
+# Default notify_on types: APPROVAL_REQUEST, REVIEW_REQUEST
+# Add QUERY_REQUEST, PROMPT_RESPONSE, etc. as desired.
+#
+# State file (deduplication):
+#   ~/.local/share/anvillm/notified-ids.txt
+#   Message IDs are persisted here so restarts do not re-notify.
+#
+# Environment:
+#   NAMESPACE  — 9P namespace path (default: /tmp/ns.$USER.:0)
+
+set -euo pipefail
+
+# ── help ──────────────────────────────────────────────────────────────────────
+
+if [[ "${1:-}" == "--help" ]]; then
+    cat <<'EOF'
+anvillm-inbox-notify — Desktop notification daemon for AnviLLM inbox messages.
+
+USAGE
+  anvillm-inbox-notify [--help]
+
+CONFIGURATION
+  ~/.config/anvillm/notifications.yaml
+    notify_on:
+      - APPROVAL_REQUEST   # default
+      - REVIEW_REQUEST     # default
+      - QUERY_REQUEST      # optional
+
+STATE FILE
+  ~/.local/share/anvillm/notified-ids.txt
+  Persists seen message IDs across restarts to prevent duplicate notifications.
+
+ENVIRONMENT
+  NAMESPACE   9P namespace directory (default: /tmp/ns.$USER.:0)
+EOF
+    exit 0
+fi
+
+# ── paths ─────────────────────────────────────────────────────────────────────
+
+CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/anvillm/notifications.yaml"
+STATE_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/anvillm"
+STATE_FILE="$STATE_DIR/notified-ids.txt"
+
+mkdir -p "$STATE_DIR"
+touch "$STATE_FILE"
+
+# ── namespace ─────────────────────────────────────────────────────────────────
+
+NAMESPACE="${NAMESPACE:-/tmp/ns.${USER}.:0}"
+export NAMESPACE
+
+# ── load config ───────────────────────────────────────────────────────────────
+
+# Parse notify_on list from YAML config, falling back to defaults.
+# Expected YAML format (subset):
+#   notify_on:
+#     - APPROVAL_REQUEST
+#     - REVIEW_REQUEST
+load_notify_on() {
+    if [[ -f "$CONFIG_FILE" ]]; then
+        # Extract lines under notify_on: that start with "  - "
+        awk '/^notify_on:/{found=1; next} found && /^  - /{gsub(/^  - /, ""); print; next} found && /^[^ ]/{exit}' "$CONFIG_FILE"
+    fi
+}
+
+NOTIFY_ON_ARRAY=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && NOTIFY_ON_ARRAY+=("$line")
+done < <(load_notify_on)
+
+# Fall back to defaults if config is absent or empty.
+if [[ ${#NOTIFY_ON_ARRAY[@]} -eq 0 ]]; then
+    NOTIFY_ON_ARRAY=("APPROVAL_REQUEST" "REVIEW_REQUEST")
+fi
+
+# Build a jq expression for type matching: (.data.type | IN("T1","T2",...))
+JQ_TYPES=$(printf '"%s",' "${NOTIFY_ON_ARRAY[@]}")
+JQ_TYPES="${JQ_TYPES%,}"  # strip trailing comma
+
+echo "anvillm-inbox-notify: watching for types: ${NOTIFY_ON_ARRAY[*]}"
+echo "anvillm-inbox-notify: namespace: $NAMESPACE"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+already_notified() {
+    grep -qxF "$1" "$STATE_FILE" 2>/dev/null
+}
+
+mark_notified() {
+    echo "$1" >> "$STATE_FILE"
+}
+
+send_notification() {
+    local from="$1" subject="$2" body="$3" msg_type="$4"
+    local urgency="normal"
+    if [[ "$msg_type" == "APPROVAL_REQUEST" ]]; then
+        urgency="critical"
+    fi
+    notify-send \
+        --urgency="$urgency" \
+        --app-name="AnviLLM" \
+        --icon=dialog-information \
+        "AnviLLM [${from}]: ${subject}" \
+        "${body}"
+}
+
+# ── event loop ────────────────────────────────────────────────────────────────
+
+# Stream events and filter with jq.  The jq filter selects UserRecv events
+# addressed to the human user whose message type is in the notify_on list.
+#
+# Full event shape:
+#   {"id":"...", "ts":..., "agent":"user", "type":"UserRecv",
+#    "data":{"id":"...", "from":"agent-id", "to":"user",
+#            "type":"APPROVAL_REQUEST", "subject":"...", "body":"..."}}
+
+JQ_FILTER="
+  select(
+    .type == \"UserRecv\"
+    and .data.to == \"user\"
+    and (.data.type | IN(${JQ_TYPES}))
+  )
+"
+
+9p read agent/events | jq --unbuffered -c "$JQ_FILTER" | while IFS= read -r event; do
+    msg_id=$(printf '%s' "$event"  | jq -r '.data.id // .id')
+    from=$(printf '%s' "$event"    | jq -r '.data.from // "unknown"')
+    subject=$(printf '%s' "$event" | jq -r '.data.subject // "(no subject)"')
+    body=$(printf '%s' "$event"    | jq -r '.data.body // ""')
+    msg_type=$(printf '%s' "$event"| jq -r '.data.type // "UNKNOWN"')
+
+    if already_notified "$msg_id"; then
+        continue
+    fi
+
+    send_notification "$from" "$subject" "$body" "$msg_type" && mark_notified "$msg_id"
+done

--- a/services/inbox-notify-runit/README.md
+++ b/services/inbox-notify-runit/README.md
@@ -1,0 +1,50 @@
+# anvillm-inbox-notify runit service
+
+Runit service for the [`anvillm-inbox-notify`](../../scripts/anvillm-inbox-notify) daemon.
+
+## What it does
+
+Streams the AnviLLM event bus (`9p read agent/events`) and fires desktop
+notifications via `notify-send` when messages of configured types arrive in
+the user's inbox.
+
+Default notification types: `APPROVAL_REQUEST`, `REVIEW_REQUEST`.
+
+Configurable via `~/.config/anvillm/notifications.yaml`:
+
+```yaml
+notify_on:
+  - APPROVAL_REQUEST
+  - REVIEW_REQUEST
+  # - QUERY_REQUEST    # uncomment to also notify on queries
+```
+
+## Installation
+
+### System-wide (runit)
+
+```sh
+sudo cp -r services/inbox-notify-runit /etc/sv/anvillm-inbox-notify
+sudo ln -s /etc/sv/anvillm-inbox-notify /var/service/anvillm-inbox-notify
+```
+
+### Per-user (runit with ~/.config/service)
+
+```sh
+mkdir -p ~/.config/service
+cp -r services/inbox-notify-runit ~/.config/service/anvillm-inbox-notify
+sv up anvillm-inbox-notify
+```
+
+### Manual (foreground)
+
+```sh
+./scripts/anvillm-inbox-notify
+```
+
+## Prerequisites
+
+- `anvillm-inbox-notify` script installed in `PATH`
+- `notify-send` (from `libnotify` or `dunst`)
+- `jq` ≥ 1.6
+- `9p` command connected to a running `anvilsrv`

--- a/services/inbox-notify-runit/finish
+++ b/services/inbox-notify-runit/finish
@@ -1,0 +1,5 @@
+#!/bin/sh
+# runit finish script for anvillm-inbox-notify
+# Called when the service stops (daemon exited or was killed).
+
+echo "anvillm-inbox-notify stopped"

--- a/services/inbox-notify-runit/run
+++ b/services/inbox-notify-runit/run
@@ -1,0 +1,32 @@
+#!/bin/sh
+# runit service script for anvillm-inbox-notify
+#
+# Monitors the AnviLLM event stream and fires desktop notifications when
+# messages of configured types (default: APPROVAL_REQUEST, REVIEW_REQUEST)
+# arrive in the user's inbox.
+#
+# To install this service:
+#   1. Copy this directory to /etc/sv/anvillm-inbox-notify
+#   2. Create symlink: ln -s /etc/sv/anvillm-inbox-notify /var/service/anvillm-inbox-notify
+#
+# Or for per-user service management with runit:
+#   mkdir -p ~/.config/service
+#   cp -r services/inbox-notify-runit ~/.config/service/anvillm-inbox-notify
+#   sv up anvillm-inbox-notify
+
+exec 2>&1
+
+export HOME="${HOME:-/home/$(whoami)}"
+export PATH="${HOME}/bin:/usr/local/bin:/usr/bin:/bin"
+export NAMESPACE="${NAMESPACE:-/tmp/ns.$(whoami).:0}"
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+
+# Make DISPLAY available for desktop notifications.
+# Adjust if your display is different (e.g., :1, wayland, etc.)
+export DISPLAY="${DISPLAY:-:0}"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u)/bus}"
+
+echo "Starting anvillm-inbox-notify..."
+
+exec chpst -u "$(whoami)" anvillm-inbox-notify

--- a/services/systemd/anvillm-inbox-notify.service
+++ b/services/systemd/anvillm-inbox-notify.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=AnviLLM Inbox Notification Daemon
+Documentation=https://github.com/lkn/anvillm
+After=default.target
+
+[Service]
+Type=simple
+
+# Inherit DISPLAY and DBUS from user session for desktop notifications.
+# Uncomment and set if your session differs from :0.
+# Environment="DISPLAY=:0"
+# Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus"
+
+# Namespace for 9P mount (default matches anvilsrv default).
+# Override if you use a non-default namespace.
+# Environment="NAMESPACE=/tmp/ns.%u.:0"
+
+ExecStart=%h/bin/anvillm-inbox-notify
+
+# Restart if the daemon exits (e.g. anvilsrv restarted and the 9p read broke).
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target

--- a/services/sysvinit/README.md
+++ b/services/sysvinit/README.md
@@ -1,0 +1,149 @@
+# SysV init scripts
+
+SysV init scripts for AnviLLM services, in two flavours:
+
+| File | Style | Install at |
+|------|-------|-----------|
+| `anvilsrv` | Generic SysV + LSB INIT INFO header | `/etc/init.d/anvilsrv` |
+| `rc.anvilsrv` | Slackware rc | `/etc/rc.d/rc.anvilsrv` |
+| `anvillm-inbox-notify` | Generic SysV + LSB INIT INFO header | `/etc/init.d/anvillm-inbox-notify` |
+| `rc.anvillm-inbox-notify` | Slackware rc | `/etc/rc.d/rc.anvillm-inbox-notify` |
+
+---
+
+## anvilsrv — AnviLLM backend server
+
+`anvilsrv` is the core backend daemon.  It exposes the `agent/` 9P filesystem
+used by Claude Code sessions, bots, the beads task store, and the event bus.
+
+The binary (`~/bin/anvilsrv`) handles daemonization, PID file management, and
+a `status` subcommand itself, so these init scripts delegate to `anvilsrv
+start`, `anvilsrv stop`, and `anvilsrv status` rather than doing their own
+process tracking.  The PID file lives at `$NAMESPACE/anvilsrv.pid`.
+
+### Generic SysV (`/etc/init.d/anvilsrv`)
+
+```sh
+# Install
+sudo install -m 755 services/sysvinit/anvilsrv /etc/init.d/
+
+# Configure — set the user to run as
+sudo sh -c 'echo "ANVILSRV_USER=yourlogin" > /etc/default/anvilsrv'
+# Optionally override NAMESPACE (defaults to /tmp/ns.$ANVILSRV_USER):
+# echo "NAMESPACE=/tmp/ns.yourlogin.:0" >> /etc/default/anvilsrv
+
+# Register with the init system
+sudo update-rc.d anvilsrv defaults   # Debian / Ubuntu
+# -or-
+sudo chkconfig --add anvilsrv        # Red Hat / CentOS
+
+# Manage
+sudo service anvilsrv start
+sudo service anvilsrv stop
+sudo service anvilsrv restart
+sudo service anvilsrv status
+```
+
+### Slackware (`/etc/rc.d/rc.anvilsrv`)
+
+```sh
+# Install binary (built from source or downloaded)
+install -m 755 /path/to/anvilsrv /home/yourlogin/bin/
+
+# Install rc script
+install -m 755 services/sysvinit/rc.anvilsrv /etc/rc.d/
+
+# Set the user — edit ANVILSRV_USER= at the top of the script, or pass it:
+ANVILSRV_USER=yourlogin /etc/rc.d/rc.anvilsrv start
+```
+
+Enable/disable (Slackware convention):
+
+```sh
+chmod 755 /etc/rc.d/rc.anvilsrv   # enable
+chmod 644 /etc/rc.d/rc.anvilsrv   # disable
+```
+
+Add to `/etc/rc.d/rc.local` to start at boot:
+
+```sh
+if [ -x /etc/rc.d/rc.anvilsrv ]; then
+  /etc/rc.d/rc.anvilsrv start
+fi
+```
+
+Add to `/etc/rc.d/rc.local_shutdown` to stop cleanly:
+
+```sh
+if [ -x /etc/rc.d/rc.anvilsrv ]; then
+  /etc/rc.d/rc.anvilsrv stop
+fi
+```
+
+---
+
+## anvillm-inbox-notify — inbox notification daemon
+
+`anvillm-inbox-notify` streams the AnviLLM event bus and fires `notify-send`
+desktop notifications when messages of configured types (default:
+`APPROVAL_REQUEST`, `REVIEW_REQUEST`) arrive in the user's inbox.  Configure
+in `~/.config/anvillm/notifications.yaml`.
+
+Because this daemon needs a graphical session (`DISPLAY`, `DBUS_SESSION_BUS_ADDRESS`),
+both scripts auto-detect those values from `/proc/<pid>/environ` for
+`ANVILLM_USER`.  See the note at the end of this file.
+
+### Generic SysV (`/etc/init.d/anvillm-inbox-notify`)
+
+```sh
+# Install daemon and init script
+sudo install -m 755 scripts/anvillm-inbox-notify /usr/local/bin/
+sudo install -m 755 services/sysvinit/anvillm-inbox-notify /etc/init.d/
+
+# Configure
+sudo sh -c 'echo "ANVILLM_USER=yourlogin" > /etc/default/anvillm-inbox-notify'
+
+# Register
+sudo update-rc.d anvillm-inbox-notify defaults
+# -or-
+sudo chkconfig --add anvillm-inbox-notify
+
+# Manage
+sudo service anvillm-inbox-notify start
+sudo service anvillm-inbox-notify stop
+sudo service anvillm-inbox-notify restart
+sudo service anvillm-inbox-notify status
+```
+
+### Slackware (`/etc/rc.d/rc.anvillm-inbox-notify`)
+
+```sh
+# Install daemon
+install -m 755 scripts/anvillm-inbox-notify /usr/local/bin/
+
+# Install rc script
+install -m 755 services/sysvinit/rc.anvillm-inbox-notify /etc/rc.d/
+
+# Set user: edit ANVILLM_USER= at the top, or pass it:
+ANVILLM_USER=yourlogin /etc/rc.d/rc.anvillm-inbox-notify start
+```
+
+Enable/disable and rc.local hooks follow the same pattern as rc.anvilsrv above.
+
+---
+
+## Note on DISPLAY / DBUS (inbox-notify only)
+
+`anvillm-inbox-notify` fires desktop notifications and therefore needs the
+target user's X11 `DISPLAY` and `DBUS_SESSION_BUS_ADDRESS`.  Both scripts
+discover these automatically by scanning `/proc/<pid>/environ` for processes
+owned by `ANVILLM_USER`, falling back to `DISPLAY=:0` and the systemd user
+bus path (`/run/user/<uid>/bus`) if nothing is found.
+
+If the X session hasn't started when the script runs the daemon will use the
+fallback values; `notify-send` will connect successfully for a standard single-
+seat setup where X is already running.
+
+For a fully session-integrated approach (no guesswork), prefer the
+[systemd user service](../systemd/anvillm-inbox-notify.service) or the
+[runit service](../inbox-notify-runit/).

--- a/services/sysvinit/anvillm-inbox-notify
+++ b/services/sysvinit/anvillm-inbox-notify
@@ -1,0 +1,185 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          anvillm-inbox-notify
+# Required-Start:    $local_fs $syslog
+# Required-Stop:     $local_fs $syslog
+# Should-Start:      $network dbus
+# Should-Stop:       $network dbus
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: AnviLLM inbox notification daemon
+# Description:       Monitors the AnviLLM event stream and delivers desktop
+#                    notifications (via notify-send) when messages of configured
+#                    types (default: APPROVAL_REQUEST, REVIEW_REQUEST) arrive in
+#                    the human user's inbox.
+### END INIT INFO
+
+# ── configuration ─────────────────────────────────────────────────────────────
+#
+# Set ANVILLM_USER to the login name of the desktop user who should receive
+# notifications.  The daemon needs that user's X11 DISPLAY and D-Bus session
+# bus address; this script discovers them automatically from /proc.
+#
+# Override in /etc/default/anvillm-inbox-notify (sourced below if it exists).
+#
+ANVILLM_USER="${ANVILLM_USER:-}"
+
+NAME="anvillm-inbox-notify"
+DAEMON="/usr/local/bin/anvillm-inbox-notify"
+PIDFILE="/var/run/${NAME}.pid"
+LOGFILE="/var/log/${NAME}.log"
+
+# Source distro defaults (if any).
+[ -r /etc/default/anvillm-inbox-notify ] && . /etc/default/anvillm-inbox-notify
+
+# ── sanity checks ─────────────────────────────────────────────────────────────
+
+if [ -z "$ANVILLM_USER" ]; then
+    echo "${NAME}: ANVILLM_USER is not set." >&2
+    echo "  Set it in /etc/default/anvillm-inbox-notify:" >&2
+    echo "    ANVILLM_USER=yourlogin" >&2
+    exit 6   # LSB: program not configured
+fi
+
+if [ ! -x "$DAEMON" ]; then
+    echo "${NAME}: daemon not found at ${DAEMON}" >&2
+    exit 5   # LSB: program not installed
+fi
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# get_env_var VAR USER
+# Read an environment variable from any running process owned by USER.
+get_env_var() {
+    local var="$1" user="$2"
+    local pid
+    pid=$(pgrep -u "$user" -x Xorg 2>/dev/null || pgrep -u "$user" -x X 2>/dev/null || pgrep -u "$user" 2>/dev/null | head -1)
+    [ -z "$pid" ] && return 1
+    # /proc/<pid>/environ is null-separated; grep for the variable and extract value
+    tr '\0' '\n' < "/proc/${pid}/environ" 2>/dev/null | grep "^${var}=" | head -1 | cut -d= -f2-
+}
+
+# discover_session_env
+# Populates DISPLAY_ENV and DBUS_ENV for ANVILLM_USER.
+discover_session_env() {
+    DISPLAY_ENV=$(get_env_var DISPLAY "$ANVILLM_USER")
+    DBUS_ENV=$(get_env_var DBUS_SESSION_BUS_ADDRESS "$ANVILLM_USER")
+
+    if [ -z "$DISPLAY_ENV" ]; then
+        # Fall back to :0 — correct for a single local X session
+        DISPLAY_ENV=":0"
+    fi
+
+    if [ -z "$DBUS_ENV" ]; then
+        # Try the well-known systemd path for the user's UID
+        local uid
+        uid=$(id -u "$ANVILLM_USER" 2>/dev/null)
+        if [ -n "$uid" ]; then
+            DBUS_ENV="unix:path=/run/user/${uid}/bus"
+        fi
+    fi
+}
+
+daemon_running() {
+    [ -s "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null
+}
+
+# ── actions ───────────────────────────────────────────────────────────────────
+
+do_start() {
+    if daemon_running; then
+        echo "${NAME} is already running (PID $(cat "$PIDFILE"))."
+        return 0   # LSB: 0 = already running is not an error
+    fi
+
+    discover_session_env
+
+    echo "Starting ${NAME} as ${ANVILLM_USER} (DISPLAY=${DISPLAY_ENV})..."
+
+    su -s /bin/sh -l "$ANVILLM_USER" -c "
+        export DISPLAY='${DISPLAY_ENV}'
+        export DBUS_SESSION_BUS_ADDRESS='${DBUS_ENV}'
+        nohup '${DAEMON}' >> '${LOGFILE}' 2>&1 &
+        echo \$! > '${PIDFILE}'
+    "
+
+    # Brief wait and confirm.
+    sleep 1
+    if daemon_running; then
+        echo "${NAME} started (PID $(cat "$PIDFILE"))."
+        return 0
+    else
+        echo "${NAME}: failed to start — check ${LOGFILE}" >&2
+        rm -f "$PIDFILE"
+        return 1
+    fi
+}
+
+do_stop() {
+    if ! daemon_running; then
+        echo "${NAME} is not running."
+        rm -f "$PIDFILE"
+        return 0   # LSB: 0 = already stopped is not an error
+    fi
+
+    local pid
+    pid=$(cat "$PIDFILE")
+    echo "Stopping ${NAME} (PID ${pid})..."
+    kill "$pid" 2>/dev/null
+    # Wait up to 5 s for the process to exit.
+    local i=0
+    while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 5 ]; do
+        sleep 1
+        i=$((i + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "${NAME}: still running after 5 s, sending SIGKILL..."
+        kill -9 "$pid" 2>/dev/null
+    fi
+    rm -f "$PIDFILE"
+    echo "${NAME} stopped."
+    return 0
+}
+
+do_status() {
+    if daemon_running; then
+        echo "${NAME} is running (PID $(cat "$PIDFILE"))."
+        return 0   # LSB status: 0 = running
+    elif [ -s "$PIDFILE" ]; then
+        echo "${NAME} is dead but PID file ${PIDFILE} exists."
+        return 1   # LSB status: 1 = dead, pidfile exists
+    else
+        echo "${NAME} is not running."
+        return 3   # LSB status: 3 = not running
+    fi
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+case "$1" in
+    start)
+        do_start
+        ;;
+    stop)
+        do_stop
+        ;;
+    restart|force-reload)
+        do_stop
+        sleep 1
+        do_start
+        ;;
+    reload)
+        # The daemon re-reads its config on next startup; no live reload needed.
+        echo "${NAME}: reload not supported — use restart instead."
+        exit 3   # LSB: unimplemented feature
+        ;;
+    status)
+        do_status
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2
+        exit 2   # LSB: invalid argument
+        ;;
+esac
+
+exit $?

--- a/services/sysvinit/anvilsrv
+++ b/services/sysvinit/anvilsrv
@@ -1,0 +1,151 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          anvilsrv
+# Required-Start:    $local_fs $syslog
+# Required-Stop:     $local_fs $syslog
+# Should-Start:      $network
+# Should-Stop:       $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: AnviLLM backend server
+# Description:       anvilsrv is the AnviLLM backend server daemon. It exposes
+#                    a 9P filesystem (agent/) that Claude Code sessions and bots
+#                    use for session management, mailbox communication, beads
+#                    task tracking, and the event bus.
+### END INIT INFO
+
+# ── configuration ─────────────────────────────────────────────────────────────
+#
+# ANVILSRV_USER  Login name of the user whose AnviLLM instance to manage.
+#                The anvilsrv binary is expected at ~/bin/anvilsrv.
+#
+# NAMESPACE      9P namespace directory. Defaults to /tmp/ns.$ANVILSRV_USER
+#                matching the Plan 9 client.Namespace() convention.
+#                The PID file lives at $NAMESPACE/anvilsrv.pid.
+#
+# Override in /etc/default/anvilsrv (sourced below if it exists).
+#
+ANVILSRV_USER="${ANVILSRV_USER:-}"
+NAMESPACE="${NAMESPACE:-}"
+
+# Source distro defaults (if any).
+[ -r /etc/default/anvilsrv ] && . /etc/default/anvilsrv
+
+# ── derived paths ─────────────────────────────────────────────────────────────
+
+NAME="anvilsrv"
+
+# Resolve NAMESPACE after potentially sourcing defaults.
+if [ -z "$NAMESPACE" ] && [ -n "$ANVILSRV_USER" ]; then
+    NAMESPACE="/tmp/ns.${ANVILSRV_USER}"
+fi
+
+# ── sanity checks ─────────────────────────────────────────────────────────────
+
+if [ -z "$ANVILSRV_USER" ]; then
+    echo "${NAME}: ANVILSRV_USER is not set." >&2
+    echo "  Set it in /etc/default/anvilsrv:" >&2
+    echo "    ANVILSRV_USER=yourlogin" >&2
+    exit 6   # LSB: program not configured
+fi
+
+DAEMON="/home/${ANVILSRV_USER}/bin/anvilsrv"
+
+if [ ! -x "$DAEMON" ]; then
+    echo "${NAME}: daemon not found at ${DAEMON}" >&2
+    exit 5   # LSB: program not installed
+fi
+
+# ── actions ───────────────────────────────────────────────────────────────────
+
+do_start() {
+    # anvilsrv start exits non-zero if already running.
+    # Let it decide — delegate fully.
+    echo "Starting ${NAME} (user=${ANVILSRV_USER}, namespace=${NAMESPACE})..."
+
+    mkdir -p "$NAMESPACE"
+    chown "$ANVILSRV_USER" "$NAMESPACE" 2>/dev/null || true
+
+    su -s /bin/sh -l "$ANVILSRV_USER" -c "
+        export NAMESPACE='${NAMESPACE}'
+        export HOME='/home/${ANVILSRV_USER}'
+        export PATH='/home/${ANVILSRV_USER}/bin:/usr/local/bin:/usr/bin:/bin'
+        '${DAEMON}' start
+    "
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "${NAME} started."
+    else
+        echo "${NAME}: start failed (exit ${rc}) — check system logs." >&2
+    fi
+    return $rc
+}
+
+do_stop() {
+    echo "Stopping ${NAME} (user=${ANVILSRV_USER})..."
+
+    su -s /bin/sh -l "$ANVILSRV_USER" -c "
+        export NAMESPACE='${NAMESPACE}'
+        export HOME='/home/${ANVILSRV_USER}'
+        export PATH='/home/${ANVILSRV_USER}/bin:/usr/local/bin:/usr/bin:/bin'
+        '${DAEMON}' stop
+    "
+    local rc=$?
+    # Clean up the 9P socket on stop (mirrors systemd ExecStopPost).
+    rm -f "${NAMESPACE}/agent" 2>/dev/null || true
+    if [ $rc -eq 0 ]; then
+        echo "${NAME} stopped."
+    fi
+    return $rc
+}
+
+do_status() {
+    su -s /bin/sh -l "$ANVILSRV_USER" -c "
+        export NAMESPACE='${NAMESPACE}'
+        export HOME='/home/${ANVILSRV_USER}'
+        export PATH='/home/${ANVILSRV_USER}/bin:/usr/local/bin:/usr/bin:/bin'
+        '${DAEMON}' status
+    "
+    local rc=$?
+    # Map anvilsrv exit codes to LSB status codes.
+    # anvilsrv status exits 0 if running, non-zero otherwise.
+    # We also check for a stale PID file.
+    if [ $rc -ne 0 ]; then
+        local pidfile="${NAMESPACE}/anvilsrv.pid"
+        if [ -s "$pidfile" ]; then
+            return 1   # LSB: dead, pidfile exists
+        fi
+        return 3       # LSB: not running
+    fi
+    return 0
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+case "$1" in
+    start)
+        do_start
+        ;;
+    stop)
+        do_stop
+        ;;
+    restart|force-reload)
+        do_stop
+        sleep 1
+        do_start
+        ;;
+    reload)
+        # anvilsrv does not support live config reload.
+        echo "${NAME}: reload not supported — use restart." >&2
+        exit 3   # LSB: unimplemented feature
+        ;;
+    status)
+        do_status
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2
+        exit 2   # LSB: invalid argument
+        ;;
+esac
+
+exit $?

--- a/services/sysvinit/rc.anvillm-inbox-notify
+++ b/services/sysvinit/rc.anvillm-inbox-notify
@@ -1,0 +1,143 @@
+#!/bin/sh
+# /etc/rc.d/rc.anvillm-inbox-notify
+#
+# Start/stop/restart the AnviLLM inbox notification daemon.
+#
+# This script follows Slackware rc conventions:
+#   - Enable service:  chmod 755 /etc/rc.d/rc.anvillm-inbox-notify
+#   - Disable service: chmod 644 /etc/rc.d/rc.anvillm-inbox-notify
+#
+# To start automatically at boot, add to /etc/rc.d/rc.local:
+#   if [ -x /etc/rc.d/rc.anvillm-inbox-notify ]; then
+#     /etc/rc.d/rc.anvillm-inbox-notify start
+#   fi
+#
+# To stop cleanly at shutdown, add to /etc/rc.d/rc.local_shutdown:
+#   if [ -x /etc/rc.d/rc.anvillm-inbox-notify ]; then
+#     /etc/rc.d/rc.anvillm-inbox-notify stop
+#   fi
+#
+# ── configuration ─────────────────────────────────────────────────────────────
+#
+# ANVILLM_USER  Login name of the desktop user who receives notifications.
+#               The daemon monitors that user's AnviLLM event stream and fires
+#               notify-send desktop notifications for APPROVAL_REQUEST and
+#               REVIEW_REQUEST messages (configurable in
+#               ~/.config/anvillm/notifications.yaml).
+#
+ANVILLM_USER="${ANVILLM_USER:-}"
+
+DAEMON="/usr/local/bin/anvillm-inbox-notify"
+PIDFILE="/var/run/anvillm-inbox-notify.pid"
+LOGFILE="/var/log/anvillm-inbox-notify.log"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# get_user_env VAR
+# Reads an environment variable from a running process owned by $ANVILLM_USER.
+# Tries the Xorg/X process first (most likely to have DISPLAY set), then any
+# process owned by that user.
+get_user_env() {
+    local var="$1"
+    local pid
+
+    pid=$(pgrep -u "$ANVILLM_USER" -x Xorg 2>/dev/null | head -1)
+    [ -z "$pid" ] && pid=$(pgrep -u "$ANVILLM_USER" -x X 2>/dev/null | head -1)
+    [ -z "$pid" ] && pid=$(pgrep -u "$ANVILLM_USER" 2>/dev/null | head -1)
+    [ -z "$pid" ] && return 1
+
+    tr '\0' '\n' < "/proc/${pid}/environ" 2>/dev/null | \
+        grep "^${var}=" | head -1 | cut -d= -f2-
+}
+
+anvillm_start() {
+    # Guard: already running?
+    if [ -s "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        echo "anvillm-inbox-notify is already running."
+        return
+    fi
+
+    if [ -z "$ANVILLM_USER" ]; then
+        echo "anvillm-inbox-notify: ANVILLM_USER is not set — edit this script or set the variable." >&2
+        return
+    fi
+
+    if [ ! -x "$DAEMON" ]; then
+        echo "anvillm-inbox-notify: ${DAEMON} not found or not executable." >&2
+        return
+    fi
+
+    # Discover the user's X11 display and D-Bus session bus address.
+    DISPLAY_VAL=$(get_user_env DISPLAY)
+    [ -z "$DISPLAY_VAL" ] && DISPLAY_VAL=":0"
+
+    DBUS_VAL=$(get_user_env DBUS_SESSION_BUS_ADDRESS)
+    if [ -z "$DBUS_VAL" ]; then
+        local uid
+        uid=$(id -u "$ANVILLM_USER" 2>/dev/null)
+        [ -n "$uid" ] && DBUS_VAL="unix:path=/run/user/${uid}/bus"
+    fi
+
+    echo "Starting anvillm-inbox-notify (user=${ANVILLM_USER}, DISPLAY=${DISPLAY_VAL})..."
+
+    su -s /bin/sh -l "$ANVILLM_USER" -c "
+        export DISPLAY='${DISPLAY_VAL}'
+        export DBUS_SESSION_BUS_ADDRESS='${DBUS_VAL}'
+        nohup '${DAEMON}' >> '${LOGFILE}' 2>&1 &
+        echo \$! > '${PIDFILE}'
+    "
+}
+
+anvillm_stop() {
+    if [ ! -s "$PIDFILE" ]; then
+        echo "anvillm-inbox-notify is not running (no PID file)."
+        return
+    fi
+
+    local pid
+    pid=$(cat "$PIDFILE")
+
+    if ! kill -0 "$pid" 2>/dev/null; then
+        echo "anvillm-inbox-notify: stale PID file — removing."
+        rm -f "$PIDFILE"
+        return
+    fi
+
+    echo "Stopping anvillm-inbox-notify (PID ${pid})..."
+    kill "$pid" 2>/dev/null
+    rm -f "$PIDFILE"
+}
+
+anvillm_restart() {
+    anvillm_stop
+    sleep 1
+    anvillm_start
+}
+
+anvillm_status() {
+    if [ -s "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        echo "anvillm-inbox-notify is running (PID $(cat "$PIDFILE"))."
+    else
+        echo "anvillm-inbox-notify is not running."
+    fi
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+case "$1" in
+    start)
+        anvillm_start
+        ;;
+    stop)
+        anvillm_stop
+        ;;
+    restart)
+        anvillm_restart
+        ;;
+    status)
+        anvillm_status
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        ;;
+esac

--- a/services/sysvinit/rc.anvilsrv
+++ b/services/sysvinit/rc.anvilsrv
@@ -1,0 +1,117 @@
+#!/bin/sh
+# /etc/rc.d/rc.anvilsrv
+#
+# Start/stop/restart the AnviLLM backend server (anvilsrv).
+#
+# anvilsrv exposes a 9P filesystem (agent/) used by Claude Code sessions and
+# bots for session management, mailbox communication, beads task tracking, and
+# the event bus.
+#
+# This script follows Slackware rc conventions:
+#   - Enable service:  chmod 755 /etc/rc.d/rc.anvilsrv
+#   - Disable service: chmod 644 /etc/rc.d/rc.anvilsrv
+#
+# To start automatically at boot, add to /etc/rc.d/rc.local:
+#   if [ -x /etc/rc.d/rc.anvilsrv ]; then
+#     /etc/rc.d/rc.anvilsrv start
+#   fi
+#
+# To stop cleanly at shutdown, add to /etc/rc.d/rc.local_shutdown:
+#   if [ -x /etc/rc.d/rc.anvilsrv ]; then
+#     /etc/rc.d/rc.anvilsrv stop
+#   fi
+#
+# ── configuration ─────────────────────────────────────────────────────────────
+#
+# ANVILSRV_USER  Login name of the user whose AnviLLM instance to manage.
+#                The anvilsrv binary is expected at ~/bin/anvilsrv.
+#
+# NAMESPACE      9P namespace directory.  Defaults to /tmp/ns.$ANVILSRV_USER
+#                matching the Plan 9 client.Namespace() convention used by
+#                anvilsrv.  The PID file lives at $NAMESPACE/anvilsrv.pid.
+#
+ANVILSRV_USER="${ANVILSRV_USER:-}"
+NAMESPACE="${NAMESPACE:-}"
+
+# ── resolve derived paths ─────────────────────────────────────────────────────
+
+if [ -z "$NAMESPACE" ] && [ -n "$ANVILSRV_USER" ]; then
+    NAMESPACE="/tmp/ns.${ANVILSRV_USER}"
+fi
+
+DAEMON="/home/${ANVILSRV_USER}/bin/anvilsrv"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+anvilsrv_env() {
+    # Print the environment preamble used in every su invocation.
+    printf "export NAMESPACE='%s'; export HOME='/home/%s'; export PATH='/home/%s/bin:/usr/local/bin:/usr/bin:/bin'" \
+        "$NAMESPACE" "$ANVILSRV_USER" "$ANVILSRV_USER"
+}
+
+check_config() {
+    if [ -z "$ANVILSRV_USER" ]; then
+        echo "rc.anvilsrv: ANVILSRV_USER is not set — edit this script or set the variable." >&2
+        return 1
+    fi
+    if [ ! -x "$DAEMON" ]; then
+        echo "rc.anvilsrv: ${DAEMON} not found or not executable." >&2
+        return 1
+    fi
+    return 0
+}
+
+anvilsrv_start() {
+    check_config || return
+
+    echo "Starting anvilsrv (user=${ANVILSRV_USER}, namespace=${NAMESPACE})..."
+    mkdir -p "$NAMESPACE"
+    chown "$ANVILSRV_USER" "$NAMESPACE" 2>/dev/null
+
+    # anvilsrv start daemonizes itself and writes its own PID file at
+    # $NAMESPACE/anvilsrv.pid.  It also detects if it is already running and
+    # exits with an error in that case — no extra guard needed here.
+    su -s /bin/sh -l "$ANVILSRV_USER" -c "$(anvilsrv_env); '${DAEMON}' start"
+}
+
+anvilsrv_stop() {
+    check_config || return
+
+    echo "Stopping anvilsrv (user=${ANVILSRV_USER})..."
+    su -s /bin/sh -l "$ANVILSRV_USER" -c "$(anvilsrv_env); '${DAEMON}' stop"
+
+    # Remove the 9P socket left behind by anvilsrv.
+    rm -f "${NAMESPACE}/agent" 2>/dev/null
+}
+
+anvilsrv_restart() {
+    anvilsrv_stop
+    sleep 1
+    anvilsrv_start
+}
+
+anvilsrv_status() {
+    check_config || return
+
+    su -s /bin/sh -l "$ANVILSRV_USER" -c "$(anvilsrv_env); '${DAEMON}' status"
+}
+
+# ── dispatch ──────────────────────────────────────────────────────────────────
+
+case "$1" in
+    start)
+        anvilsrv_start
+        ;;
+    stop)
+        anvilsrv_stop
+        ;;
+    restart)
+        anvilsrv_restart
+        ;;
+    status)
+        anvilsrv_status
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status}"
+        ;;
+esac


### PR DESCRIPTION
## Summary

- **Beads schema** (`bd-i4h.4`): adds `pending-approval` / `pending-review` / `resume` ctl commands, a `pending` read endpoint, `StatusPendingApproval`/`StatusPendingReview` constants, and documents the `requires-approval`/`requires-review` label conventions in `BEADS.md`
- **Conductor bot** (`bd-i4h.2`): reads a custom context prompt from stdin when not a terminal; extends the default prompt with approval gate workflow instructions
- **Human notification daemon** (`bd-i4h.1`): adds `scripts/anvillm-inbox-notify` (streams `agent/events`, fires `notify-send` for `APPROVAL_REQUEST` / `REVIEW_REQUEST` by default) with service files for **runit**, **systemd**, **SysV LSB**, and **Slackware rc**
- **anvilsrv init scripts**: SysV LSB and Slackware rc scripts for the main server

## Test plan

- [ ] Start anvillm server and verify `agent/beads/pending` endpoint lists beads awaiting approval/review
- [ ] Send `pending-approval` ctl command to a bead and confirm status changes to `pending-approval`
- [ ] Send `resume` ctl command and confirm bead resumes normal status
- [ ] Run `scripts/anvillm-inbox-notify` and confirm `notify-send` fires on `APPROVAL_REQUEST` messages
- [ ] Test each init script variant (runit, systemd, SysV) starts/stops the notify daemon correctly
- [ ] Launch Conductor with a custom stdin prompt and verify it uses the injected context

🤖 Generated with [Claude Code](https://claude.com/claude-code)