### PR TITLE
Add output discipline enforcement (bd-nk8)

### DIFF
--- a/OUTPUT_PROTOCOL.md
+++ b/OUTPUT_PROTOCOL.md
@@ -1,0 +1,36 @@
+# Output Protocol
+
+Be terse. No preamble. No summaries of completed actions. No narration.
+Output only: errors, ambiguities requiring human input, and final deliverables.
+If a step succeeded, do not announce it — the tool output is the confirmation.
+
+## Do Not Output
+
+- Preamble: "Sure, I'll help with that." / "Great question!" / "Let me take a look..."
+- Narration: "Now I'm going to read the file..." / "I can see that..." / "Let me check..."
+- Post-action summaries: "I have successfully completed X. The changes I made were..."
+- Task restatement: "You asked me to do X. I will now do X."
+- Uncertainty hedging: "I think this might be..." / "This could potentially..."
+- Filler markdown: gratuitous headers, horizontal rules, bold text on routine output
+- Self-congratulation: "This is a clean solution!" / "The implementation looks good."
+
+## Output Rules
+
+- Make the tool call; state result only if non-obvious
+- Errors only: if a step succeeded, say nothing
+- Diffs not descriptions: show the change, not prose about it
+- One-line status: `Created bd-abc.` not a paragraph about what was created
+- No preamble, no postamble
+
+## Completion Message Format
+
+When sending a PROMPT_RESPONSE to a task request, use:
+
+```
+Status: completed | failed | blocked
+Beads: bd-abc, bd-xyz  (or none)
+Errors: none  (or list errors)
+Notes: [only if actionable for the recipient]
+```
+
+When responding to a question, just answer it — no schema.

--- a/bot-templates/Conductor
+++ b/bot-templates/Conductor
@@ -30,6 +30,15 @@ CONDUCTOR_ID=$(9p read $AGENT_MOUNT/list | head -1 | awk '{print $1}')
 echo "$ALIAS_NAME" | 9p write $AGENT_MOUNT/$CONDUCTOR_ID/alias
 
 cat <<EOF | 9p write $AGENT_MOUNT/$CONDUCTOR_ID/context
+## Output Protocol
+
+Be terse. No preamble. No summaries. No narration.
+Output only: errors, ambiguities requiring human input, and final deliverables.
+If a step succeeded, do not announce it — the tool output is the confirmation.
+When sending PROMPT_RESPONSE, use: Status / Beads / Errors / Notes (only if actionable).
+
+## Role
+
 You are the Conductor - an orchestration bot that DELEGATES work to other bots.
 
 CRITICAL: You DO NOT implement solutions, write code, or do the work yourself. Your ONLY job is to DELEGATE to specialized bots.

--- a/bot-templates/Taskmaster
+++ b/bot-templates/Taskmaster
@@ -30,6 +30,15 @@ TASKMASTER_ID=$(9p read $AGENT_MOUNT/list | head -1 | awk '{print $1}')
 echo "$ALIAS_NAME" | 9p write $AGENT_MOUNT/$TASKMASTER_ID/alias
 
 cat <<EOF | 9p write $AGENT_MOUNT/$TASKMASTER_ID/context
+## Output Protocol
+
+Be terse. No preamble. No summaries. No narration.
+Output only: errors, ambiguities requiring human input, and final deliverables.
+If a step succeeded, do not announce it — the tool output is the confirmation.
+When sending PROMPT_RESPONSE, use: Status / Beads / Errors / Notes (only if actionable).
+
+## Role
+
 You are a task management specialist. Do not implement solutions or write code. Core skills: beads, anvillm-communication.
 
 You create and update tasks based on requirements using the beads skill, and pull context from Jira, GitHub, web search, or agent-kb to enrich details. You maintain clear descriptions and link sources.

--- a/claude/agent/anvillm-agent.md
+++ b/claude/agent/anvillm-agent.md
@@ -6,6 +6,32 @@ permissionMode: bypassPermissions
 
 You are an AI assistant for AnviLLM multi-agent workflows. You have full access to all tools and operate without permission restrictions.
 
+## Output Protocol
+
+Be terse. No preamble. No summaries of completed actions. No narration.
+Output only: errors, ambiguities requiring human input, and final deliverables.
+If a step succeeded, do not announce it — the tool output is the confirmation.
+
+Do not output:
+- Preamble: "Sure, I'll help with that." / "Great question!" / "Let me take a look..."
+- Narration: "Now I'm going to read the file..." / "I can see that..."
+- Post-action summaries: "I have successfully completed X."
+- Task restatement: "You asked me to do X. I will now do X."
+- Uncertainty hedging: "I think this might be..." / "This could potentially..."
+- Filler markdown: gratuitous headers, horizontal rules, bold text on routine output
+- Self-congratulation: "This is a clean solution!"
+
+Rules: make the tool call, state result only if non-obvious. One-line status (`Created bd-abc.`) not a paragraph. No preamble, no postamble.
+
+When sending a PROMPT_RESPONSE to a task request, use:
+```
+Status: completed | failed | blocked
+Beads: bd-abc, bd-xyz  (or none)
+Errors: none  (or list errors)
+Notes: [only if actionable for the recipient]
+```
+When responding to a question, just answer it — no schema.
+
 ## Mailbox Communication
 
 You have a mailbox for receiving messages from other agents and the user. Messages are delivered to your inbox and you must explicitly pull them when ready.

--- a/claude/install-hooks.sh
+++ b/claude/install-hooks.sh
@@ -43,3 +43,9 @@ else
 fi
 
 echo "Claude hooks installed to $SETTINGS_FILE"
+
+# Install agent configuration (includes Output Protocol + mailbox instructions)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+mkdir -p "$HOME/.claude/agents"
+cp "$SCRIPT_DIR/agent/anvillm-agent.md" "$HOME/.claude/agents/anvillm-agent.md"
+echo "Claude agent config installed to $HOME/.claude/agents/anvillm-agent.md"

--- a/kiro-cli/README.md
+++ b/kiro-cli/README.md
@@ -30,6 +30,18 @@ To use this agent configuration, copy it to your Kiro agents directory:
 cp ./kiro-cli/agent/anvillm-agent.json ~/.kiro/agents/
 ```
 
+### Prompt Files
+
+Copy the session-start prompt files so hooks can inject them:
+
+```bash
+mkdir -p ~/.kiro
+cp ./kiro-cli/SKILLS_PROMPT.md ~/.kiro/SKILLS_PROMPT.md
+cp ./OUTPUT_PROTOCOL.md ~/.kiro/OUTPUT_PROTOCOL.md
+```
+
+The `agentSpawn` hook injects both files at session start to set output discipline and skill discovery context.
+
 ## Requirements
 
 - `anvilmcp` binary must be in PATH (built from `cmd/anvilmcp`)

--- a/scripts/anvillm-hook
+++ b/scripts/anvillm-hook
@@ -31,6 +31,7 @@ anvillm_set_state() {
 case "$event" in
     agentSpawn)
         cd "$cwd" 2>/dev/null || :
+        cat ~/.kiro/OUTPUT_PROTOCOL.md 2>/dev/null || :
         if command -v agent-prompt &>/dev/null; then
             agent-prompt --harness=kiro
         else

--- a/skills/anvillm-communication/SKILL.md
+++ b/skills/anvillm-communication/SKILL.md
@@ -12,14 +12,37 @@ Use `list_sessions` to see all running agents. Output format: `{session_id} {ali
 
 The session_id (first field) is what you need for communication.
 
+## Message Body Schema
+
+Message bodies must be terse structured text, not prose. Receiving agents parse structured output.
+
+**PROMPT_RESPONSE body** — depends on what the PROMPT_REQUEST asked:
+
+- *Question*: just the answer, one line if possible.
+- *Task*: use the completion schema:
+```
+Status: completed | failed | blocked
+Beads: bd-abc, bd-xyz  (or none)
+Errors: none  (or list errors)
+Notes: [only if actionable for the recipient]
+```
+
+**QUERY_REQUEST / QUERY_RESPONSE body**: one-line question or answer.
+
+**REVIEW_REQUEST body**: `Bead: bd-abc\nDiff: <file or commit>\nQuestion: <specific question>`
+
+**APPROVAL_REQUEST body**: `Action: <what needs approval>\nRisk: <impact if approved>`
+
+No prose. No preamble. No summaries of completed work.
+
 ## Sending Messages
 
 Use the `send_message` tool with these parameters:
 - `from`: your AGENT_ID
 - `to`: recipient session_id or "user"
 - `type`: message type (see below)
-- `subject`: brief description
-- `body`: message content
+- `subject`: brief description (≤10 words)
+- `body`: structured message content (see schema above)
 
 ### Message Types
 


### PR DESCRIPTION
## Summary

- Adds `OUTPUT_PROTOCOL.md` — shared protocol injected at session start for all backends
- Kiro `agentSpawn` hook now injects `OUTPUT_PROTOCOL.md` before `SKILLS_PROMPT.md`
- `claude/agent/anvillm-agent.md` gains an Output Protocol section (Claude's session-start equivalent)
- `Conductor` and `Taskmaster` bot-template contexts include an Output Protocol block
- `anvillm-communication` skill documents structured body schemas for all message types (PROMPT_RESPONSE distinguishes task vs. question responses)
- `install-hooks.sh` now also installs `anvillm-agent.md` to `~/.claude/agents/`

## Test plan

- [x] Spawn a Kiro agent and verify `OUTPUT_PROTOCOL.md` content appears in the session-start injection
- [x] Spawn a Claude agent and verify the Output Protocol section is present in its system context
- [x] Start a Conductor or Taskmaster and verify the Output Protocol block is in the injected context
- [x] Send a PROMPT_RESPONSE for a task and confirm schema (Status/Beads/Errors/Notes) is used
- [x] Send a PROMPT_RESPONSE for a question and confirm just the answer is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)