### PR TITLE
Optimize bead description quality (bd-3bu)

### DIFF
--- a/bot-templates/Conductor
+++ b/bot-templates/Conductor
@@ -96,12 +96,30 @@ Before assigning any bead with priority 1 or 2 to a bot, apply the cold-completi
   3. Does it state the pattern to follow (not just the goal)?
   4. Does it define acceptance criteria in observable terms?
   5. Could a bot complete this with zero codebase exploration?
+  6. Do all file references use correct Acme address syntax (see File Addressing below)?
 
 If the answer to any question is "no", enrich the description before assigning:
   echo "update <bead-id> description '<enriched text>'" | 9p write agent/ctl
 
-Only assign P1/P2 beads to bots after all five questions answer "yes".
+Only assign P1/P2 beads to bots after all six questions answer "yes".
 P3+ beads may be assigned without this gate.
+
+## File Addressing
+
+When referencing source locations in bead descriptions, always use Acme/sam address syntax.
+
+**Correct forms:**
+  file.go:123            line 123
+  file.go:123,125        lines 123 to 125 (comma range)
+  file.go:/funcName/     regex search (pattern must be 4+ chars)
+  file.go:#4096          character position 4096
+
+**Wrong — do not use:**
+  file.go:123-125        hyphen range is invalid in Acme (use comma)
+  filename:L123          L-prefix is a non-standard convention
+
+The linter in the beads server will warn when it detects file:N-N hyphen ranges.
+Wrap all identifiers in backticks: \`lintDescription()\`, \`--no-lint\`.
 EOF
 
 echo ""

--- a/bot-templates/Taskmaster
+++ b/bot-templates/Taskmaster
@@ -126,6 +126,27 @@ Select the template by issue_type and fill it in:
 Write acceptance criteria in terms of observable behavior, not intent:
   ✓ "echo new title desc | 9p write agent/beads/ctl emits a lint warning to stderr"
   ✗ "the lint check should work correctly"
+
+## File Addressing
+
+When writing "Where" fields or any source location reference, use Acme/sam address syntax.
+
+**Correct forms:**
+  file.go:123            line 123
+  file.go:123,125        lines 123 to 125 (comma range)
+  file.go:/funcName/     regex search (pattern must be 4+ chars)
+  file.go:#4096          character position 4096
+
+**Wrong — do not use:**
+  file.go:123-125        hyphen range is invalid in Acme (use comma)
+  filename:L123          L-prefix is a non-standard convention
+
+Grammar reference: /home/lkn/plan9/plumb/fileaddr
+  addrelem = (#?[0-9]+) | (/[A-Za-z0-9_^]+/?) | [.$]
+  addr     = addrelem ([,;+-] addrelem)*
+
+The beads linter warns on hyphen ranges and missing backtick identifiers.
+Always wrap identifiers in backticks: \`lintDescription()\`, \`--flag\`, \`TypeName\`.
 EOF
 
 echo ""

--- a/internal/p9/beads.go
+++ b/internal/p9/beads.go
@@ -610,13 +610,25 @@ func (b *BeadsFS) executeCtl(cmd string) error {
 
 // lintDescription checks a bead description for quality signals and returns
 // a list of warning messages. An empty slice means the description passed.
-// Checks: file path present, function name or line number present,
-// minimum length, acceptance criterion keyword present.
+//
+// Rules enforced:
+//   - File path present (.go/.py/etc or /internal/ etc.)
+//   - Function name or precise location (foo(), func keyword, Acme address, L123)
+//   - Minimum length (80 chars)
+//   - Acceptance criterion keyword (should/must/returns/etc.)
+//   - Acme address format (file:N,N not file:N-N)
+//   - Imperative verb start (Fix/Add/Update/... not "Need to"/"Should")
+//   - No vague language (somehow/maybe/etc.)
+//   - "How" signal (following/same as/pattern from/...)
+//   - No first-person voice (I need/we want/...)
+//   - No forbidden vague phrases (fix this/update this/...)
+//   - Inline code (backtick identifier required when file path present)
+//   - Cross-reference on long descriptions (bd-XXX or URL for >150 chars)
 func lintDescription(description string) []string {
 	var warnings []string
 	lower := strings.ToLower(description)
 
-	// Check for file path signal: file extension or path component
+	// --- Rule 1: File path signal ---
 	hasFilePath := strings.Contains(description, ".go") ||
 		strings.Contains(description, ".py") ||
 		strings.Contains(description, ".ts") ||
@@ -630,23 +642,25 @@ func lintDescription(description string) []string {
 		warnings = append(warnings, "missing file path (add .go/.py/etc or /cmd//internal/ to help bots locate the code)")
 	}
 
-	// Check for function name or line number signal.
-	// Matches: func calls (foo()), "func " keyword, ":NNN" line refs, "L123" refs.
+	// --- Rule 2: Function name or precise location ---
+	// Matches: func calls (foo()), "func " keyword, Acme addresses (file:NNN or file:/re/),
+	// explicit "line " text, or L123 / :123 style refs.
 	hasFuncOrLine := strings.Contains(description, "()") ||
 		strings.Contains(description, "func ") ||
 		strings.Contains(lower, "line ") ||
 		strings.Contains(lower, ":line") ||
-		containsLineRef(description)
+		containsLineRef(description) ||
+		containsAcmeRegexAddr(description)
 	if !hasFuncOrLine {
-		warnings = append(warnings, "missing function name or line number (add func name or L123 reference)")
+		warnings = append(warnings, "missing function name or location (add func name, Acme address file.go:123, or L123)")
 	}
 
-	// Check minimum length
+	// --- Rule 3: Minimum length ---
 	if len(description) < 80 {
 		warnings = append(warnings, "description too short (aim for 80+ chars with What/Where/How/Accept)")
 	}
 
-	// Check for acceptance criterion keyword
+	// --- Rule 4: Acceptance criterion keyword ---
 	acceptKeywords := []string{"should", "returns", "displays", "must", "assert", "verify", "accept", "expect"}
 	hasAccept := false
 	for _, kw := range acceptKeywords {
@@ -659,18 +673,180 @@ func lintDescription(description string) []string {
 		warnings = append(warnings, "missing acceptance criterion (add: should/returns/must/accept)")
 	}
 
+	// --- Rule 5: Acme address format ---
+	// file:NNN-NNN uses a hyphen range which is invalid in Acme/sam; use comma: file:NNN,NNN.
+	if containsHyphenRange(description) {
+		warnings = append(warnings, "invalid Acme address: use comma range file.go:123,125 not file.go:123-125")
+	}
+
+	// --- Rule 6: Imperative verb start ---
+	// Warn if description begins with a known non-imperative pattern.
+	nonImperativeStarters := []string{
+		"need to ", "needs to ", "should ", "we need", "we want", "we should",
+		"the ", "this ", "looking at", "looking into",
+	}
+	firstWordLower := strings.ToLower(strings.TrimSpace(description))
+	for _, starter := range nonImperativeStarters {
+		if strings.HasPrefix(firstWordLower, starter) {
+			warnings = append(warnings, "start with imperative verb (Fix/Add/Update/Refactor) not '"+starter+"...'")
+			break
+		}
+	}
+
+	// --- Rule 7: No vague language ---
+	vaguePhrases := []string{
+		"somehow", " maybe ", "probably ", "try to ", " a bit ", " etc.", " etc,",
+		"and so on", " stuff", "some kind of", "whatever", "sort of ", "kind of ",
+	}
+	for _, phrase := range vaguePhrases {
+		if strings.Contains(lower, phrase) {
+			warnings = append(warnings, "vague language '"+strings.TrimSpace(phrase)+"': replace with specific behavior")
+			break
+		}
+	}
+
+	// --- Rule 8: "How" signal (existing pattern reference) ---
+	howSignals := []string{
+		"following ", "pattern from", "same as ", "similar to ", "like in ",
+		"mirrors ", "as in ", "modeled on", "following the ", "see ", "cf.",
+	}
+	hasHow := false
+	for _, sig := range howSignals {
+		if strings.Contains(lower, sig) {
+			hasHow = true
+			break
+		}
+	}
+	if !hasHow {
+		warnings = append(warnings, "missing 'how' signal (add: 'following pattern in X' or 'same as Y')")
+	}
+
+	// --- Rule 9: No first-person voice ---
+	firstPersonPhrases := []string{
+		"i need", "i want", "i think", "i'll ", "i will ", "i should",
+		"we need", "we want", "we should", "we'll ", "we will ",
+	}
+	for _, fp := range firstPersonPhrases {
+		if strings.Contains(lower, fp) {
+			warnings = append(warnings, "avoid first-person ('"+strings.TrimSpace(fp)+"'): use imperative voice")
+			break
+		}
+	}
+
+	// --- Rule 10: Forbidden vague phrases ---
+	forbiddenPhrases := []string{
+		"fix this", "fix it", "update this", "make it work", "clean this up",
+		"refactor this", "look at this", "deal with this", "handle this",
+	}
+	for _, fp := range forbiddenPhrases {
+		if strings.Contains(lower, fp) {
+			warnings = append(warnings, "forbidden vague phrase '"+fp+"': specify What/Where/How/Accept")
+			break
+		}
+	}
+
+	// --- Rule 11: Inline code (backtick identifier) ---
+	// When a file path is present, at least one backtick-enclosed identifier is expected.
+	if hasFilePath && !strings.Contains(description, "`") {
+		warnings = append(warnings, "no inline code found: wrap identifiers in backticks (`funcName()`, `--flag`)")
+	}
+
+	// --- Rule 12: Cross-reference on long descriptions ---
+	// Descriptions over 150 chars should reference a related bead or URL.
+	if len(description) > 150 {
+		hasBdRef := containsBdRef(description)
+		hasURL := strings.Contains(lower, "http://") || strings.Contains(lower, "https://")
+		if !hasBdRef && !hasURL {
+			warnings = append(warnings, "long description missing cross-reference (add bd-XXX or URL in Refs)")
+		}
+	}
+
 	return warnings
 }
 
 // containsLineRef returns true if s contains a line number reference
 // in the form L<digits> (e.g. L385) or :<digits> (e.g. :385).
+// Also recognises Acme character-position addresses: #<digits>.
 func containsLineRef(s string) bool {
 	for i := 0; i < len(s)-1; i++ {
-		if (s[i] == 'L' || s[i] == ':') && s[i+1] >= '0' && s[i+1] <= '9' {
+		c := s[i]
+		next := s[i+1]
+		if (c == 'L' || c == ':' || c == '#') && next >= '0' && next <= '9' {
 			return true
 		}
 	}
 	return false
+}
+
+// containsAcmeRegexAddr returns true if s contains an Acme regex-style address
+// of the form /word/ where word is at least 4 characters long
+// (e.g. /lintDescription/ or /funcName/). Short slash-delimited tokens
+// such as path components (/p9/, /cmd/, /src/) are intentionally excluded.
+func containsAcmeRegexAddr(s string) bool {
+	const minPatternLen = 4
+	for i := 0; i < len(s)-2; i++ {
+		if s[i] != '/' {
+			continue
+		}
+		// Scan for closing slash; stop at whitespace or newline.
+		j := i + 1
+		for j < len(s) && s[j] != '/' && s[j] != ' ' && s[j] != '\n' {
+			j++
+		}
+		if j < len(s) && s[j] == '/' && (j-i-1) >= minPatternLen {
+			return true
+		}
+	}
+	return false
+}
+
+// containsHyphenRange returns true if s contains an Acme-invalid hyphen range
+// of the form file.ext:NNN-NNN (e.g. beads.go:123-125).
+// The correct Acme syntax uses a comma: beads.go:123,125.
+func containsHyphenRange(s string) bool {
+	// Look for patterns like ":NNN-NNN" (colon, digits, hyphen, digits).
+	for i := 0; i < len(s); i++ {
+		if s[i] != ':' {
+			continue
+		}
+		i++
+		// Consume leading digits.
+		if i >= len(s) || s[i] < '0' || s[i] > '9' {
+			continue
+		}
+		for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+			i++
+		}
+		// Expect hyphen followed by digits.
+		if i < len(s)-1 && s[i] == '-' && s[i+1] >= '0' && s[i+1] <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+// containsBdRef returns true if s contains a bead cross-reference of the
+// form "bd-" followed by one or more lowercase alphanumeric characters.
+func containsBdRef(s string) bool {
+	lower := strings.ToLower(s)
+	idx := strings.Index(lower, "bd-")
+	for idx != -1 {
+		rest := lower[idx+3:]
+		if len(rest) > 0 && isAlphanumeric(rest[0]) {
+			return true
+		}
+		next := strings.Index(lower[idx+1:], "bd-")
+		if next == -1 {
+			break
+		}
+		idx = idx + 1 + next
+	}
+	return false
+}
+
+// isAlphanumeric returns true if b is a lowercase letter or digit.
+func isAlphanumeric(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
 }
 
 func (b *BeadsFS) createSubtask(parentID, title, description, actor string) error {

--- a/internal/p9/beads_lint_test.go
+++ b/internal/p9/beads_lint_test.go
@@ -1,0 +1,336 @@
+package p9
+
+import (
+	"strings"
+	"testing"
+)
+
+// goodDesc is a well-formed description that should pass all lint rules.
+// It contains: file path, backtick identifier, Acme address, acceptance
+// criterion, how signal, imperative start, and a cross-reference.
+const goodDesc = "Add `lintDescription()` check in `internal/p9/beads.go:615,663` following the pattern of existing checks; the function must return a non-empty warnings slice when the description violates any rule. See bd-9y4 for full rule list."
+
+func warnCount(desc, substr string) bool {
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGoodDescPassesAll verifies that a high-quality description triggers no warnings.
+func TestGoodDescPassesAll(t *testing.T) {
+	warnings := lintDescription(goodDesc)
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for good description, got: %v", warnings)
+	}
+}
+
+// --- Rule 1: File path ---
+
+func TestMissingFilePath(t *testing.T) {
+	desc := "Add a helper function following the existing pattern; it must return an error when the input is empty."
+	if !warnCount(desc, "missing file path") {
+		t.Error("expected 'missing file path' warning")
+	}
+}
+
+func TestFilePathPresent(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42` following the existing pattern; it must return an error when input is empty. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "missing file path") {
+			t.Errorf("unexpected 'missing file path' warning for desc with .go extension")
+		}
+	}
+}
+
+// --- Rule 2: Function name or location ---
+
+func TestMissingFuncOrLine(t *testing.T) {
+	desc := "Update internal/p9/beads.go following the existing pattern; the file must compile without errors after the change. See bd-abc for context."
+	if !warnCount(desc, "missing function name") {
+		t.Error("expected 'missing function name or location' warning")
+	}
+}
+
+func TestFuncNamePresent(t *testing.T) {
+	desc := "Fix `lintDescription()` in `internal/p9/beads.go` following the existing pattern; it must return warnings for vague descriptions. See bd-9y4."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "missing function name") {
+			t.Errorf("unexpected location warning when func name present")
+		}
+	}
+}
+
+func TestAcmeLineAddrRecognised(t *testing.T) {
+	desc := "Fix `foo()` in `cmd/server.go:385` following the existing error-handling pattern; it must return a wrapped error. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "missing function name") {
+			t.Errorf("unexpected location warning when Acme line address present")
+		}
+	}
+}
+
+func TestAcmeRegexAddrRecognised(t *testing.T) {
+	desc := "Update `internal/p9/beads.go:/lintDescription/` following the existing pattern; it must emit a warning for vague language. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "missing function name") {
+			t.Errorf("unexpected location warning when Acme /regex/ address present")
+		}
+	}
+}
+
+// --- Rule 3: Minimum length ---
+
+func TestTooShort(t *testing.T) {
+	if !warnCount("Fix bug.", "too short") {
+		t.Error("expected 'too short' warning for very short description")
+	}
+}
+
+// --- Rule 4: Acceptance criterion ---
+
+func TestMissingAcceptance(t *testing.T) {
+	desc := "Add `helper()` to `internal/util.go:42` following the existing pattern; the function handles empty input gracefully with a cross-reference to bd-abc."
+	if !warnCount(desc, "acceptance criterion") {
+		t.Error("expected 'acceptance criterion' warning")
+	}
+}
+
+func TestAcceptancePresent(t *testing.T) {
+	desc := "Add `helper()` to `internal/util.go:42` following the existing pattern; it must return an error on empty input. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "acceptance criterion") {
+			t.Errorf("unexpected acceptance warning when 'must' keyword present")
+		}
+	}
+}
+
+// --- Rule 5: Acme address format ---
+
+func TestHyphenRangeWarning(t *testing.T) {
+	desc := "Fix `lintDescription()` in `internal/p9/beads.go:611-663` following the existing pattern; it must return warnings correctly. See bd-abc for context."
+	if !warnCount(desc, "invalid Acme address") {
+		t.Error("expected 'invalid Acme address' warning for hyphen range")
+	}
+}
+
+func TestCommaRangeNoWarning(t *testing.T) {
+	desc := "Fix `lintDescription()` in `internal/p9/beads.go:611,663` following the existing pattern; it must return warnings correctly. See bd-abc for context."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "invalid Acme address") {
+			t.Errorf("unexpected Acme address warning for correct comma range")
+		}
+	}
+}
+
+// --- Rule 6: Imperative verb start ---
+
+func TestNonImperativeStart(t *testing.T) {
+	desc := "Need to add `helper()` in `internal/util.go:42` following existing pattern; it must return error on empty input. See bd-abc."
+	if !warnCount(desc, "imperative verb") {
+		t.Error("expected imperative verb warning for 'Need to' start")
+	}
+}
+
+func TestImperativeStart(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42` following existing pattern; it must return error on empty input. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "imperative verb") {
+			t.Errorf("unexpected imperative verb warning for description starting with 'Add'")
+		}
+	}
+}
+
+// --- Rule 7: Vague language ---
+
+func TestVagueLanguage(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42` following existing pattern; it must somehow return an error etc. See bd-abc."
+	if !warnCount(desc, "vague language") {
+		t.Error("expected vague language warning for 'somehow'")
+	}
+}
+
+func TestNoVagueLanguage(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42` following existing pattern; it must return a wrapped error on empty input. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "vague language") {
+			t.Errorf("unexpected vague language warning for precise description")
+		}
+	}
+}
+
+// --- Rule 8: "How" signal ---
+
+func TestMissingHowSignal(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42`; it must return an error on empty input. Cross-reference: bd-abc."
+	if !warnCount(desc, "how' signal") {
+		t.Error("expected 'how' signal warning")
+	}
+}
+
+func TestHowSignalPresent(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42` following the existing error-handling pattern; it must return an error on empty input. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "how' signal") {
+			t.Errorf("unexpected 'how' warning when 'following' keyword present")
+		}
+	}
+}
+
+// --- Rule 9: No first-person ---
+
+func TestFirstPersonWarning(t *testing.T) {
+	desc := "I need to add `helper()` in `internal/util.go:42` following existing pattern; it must return error on empty input. See bd-abc."
+	if !warnCount(desc, "first-person") {
+		t.Error("expected first-person warning for 'I need'")
+	}
+}
+
+func TestNoFirstPerson(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42` following existing pattern; it must return error on empty input. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "first-person") {
+			t.Errorf("unexpected first-person warning for imperative description")
+		}
+	}
+}
+
+// --- Rule 10: Forbidden vague phrases ---
+
+func TestForbiddenPhrase(t *testing.T) {
+	desc := "Fix this in `internal/util.go:42` following existing pattern; it must return error on empty input. See bd-abc."
+	if !warnCount(desc, "forbidden vague phrase") {
+		t.Error("expected forbidden phrase warning for 'fix this'")
+	}
+}
+
+func TestNoForbiddenPhrase(t *testing.T) {
+	desc := "Fix `lintDescription()` in `internal/p9/beads.go:615` following the existing pattern; it must return warnings for vague descriptions. See bd-9y4."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "forbidden vague phrase") {
+			t.Errorf("unexpected forbidden phrase warning for well-formed description")
+		}
+	}
+}
+
+// --- Rule 11: Inline code (backticks) ---
+
+func TestMissingBacktick(t *testing.T) {
+	desc := "Add helper() in internal/util.go:42 following existing pattern; it must return error on empty input. See bd-abc."
+	if !warnCount(desc, "inline code") {
+		t.Error("expected inline code warning when file path present but no backticks")
+	}
+}
+
+func TestBacktickPresent(t *testing.T) {
+	desc := "Add `helper()` in `internal/util.go:42` following existing pattern; it must return error on empty input. See bd-abc."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "inline code") {
+			t.Errorf("unexpected inline code warning when backtick identifier present")
+		}
+	}
+}
+
+// --- Rule 12: Cross-reference on long descriptions ---
+
+func TestLongDescMissingCrossRef(t *testing.T) {
+	// >150 chars, has file path and backtick, but no bd-XXX or URL
+	desc := "Add `lintDescription()` check in `internal/p9/beads.go:615` following the pattern of existing checks; the function must return a non-empty warnings slice when the description violates any rule and emit all applicable warnings."
+	if !warnCount(desc, "cross-reference") {
+		t.Error("expected cross-reference warning for long description without bd- ref")
+	}
+}
+
+func TestLongDescWithCrossRef(t *testing.T) {
+	desc := "Add `lintDescription()` check in `internal/p9/beads.go:615` following the pattern of existing checks; the function must return a non-empty warnings slice when the description violates any rule and emit all applicable warnings. See bd-9y4."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "cross-reference") {
+			t.Errorf("unexpected cross-reference warning when bd- ref present")
+		}
+	}
+}
+
+func TestShortDescNoCrossRefWarning(t *testing.T) {
+	// <=150 chars should not trigger the cross-reference rule
+	desc := "Add `helper()` in `internal/util.go:42` following existing pattern; it must return error on empty input."
+	for _, w := range lintDescription(desc) {
+		if strings.Contains(w, "cross-reference") {
+			t.Errorf("unexpected cross-reference warning for short description")
+		}
+	}
+}
+
+// --- Helper function unit tests ---
+
+func TestContainsLineRef(t *testing.T) {
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"beads.go:385", true},
+		{"see L385 for details", true},
+		{"char pos #4096", true},
+		{"no address here", false},
+	}
+	for _, tc := range cases {
+		if got := containsLineRef(tc.s); got != tc.want {
+			t.Errorf("containsLineRef(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestContainsAcmeRegexAddr(t *testing.T) {
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"beads.go:/lintDescription/", true},
+		{"see /funcName/ in the file", true},
+		{"no slashes", false},
+		{"a/b/c directory path", false},          // single-char tokens, below 4-char minimum
+		{"internal/p9/beads.go", false},           // short path components (/p9/ = 2 chars)
+		{"internal/pkg/beads.go", false},          // /pkg/ = 3 chars, below minimum
+		{"see /handleNewCommand/ here", true},     // 16 chars >= 4
+	}
+	for _, tc := range cases {
+		if got := containsAcmeRegexAddr(tc.s); got != tc.want {
+			t.Errorf("containsAcmeRegexAddr(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestContainsHyphenRange(t *testing.T) {
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"beads.go:123-125", true},
+		{"beads.go:123,125", false},
+		{"beads.go:123", false},
+		{"version 1-2", false}, // no colon before
+	}
+	for _, tc := range cases {
+		if got := containsHyphenRange(tc.s); got != tc.want {
+			t.Errorf("containsHyphenRange(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestContainsBdRef(t *testing.T) {
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"see bd-abc for context", true},
+		{"bd-9y4 and bd-iti", true},
+		{"bd- no alphanumeric", false},
+		{"no reference here", false},
+	}
+	for _, tc := range cases {
+		if got := containsBdRef(tc.s); got != tc.want {
+			t.Errorf("containsBdRef(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}

--- a/skills/beads/SKILL.md
+++ b/skills/beads/SKILL.md
@@ -170,6 +170,62 @@ When a bead looks relevant, read its full event history to see comments — this
 
 Context belongs *in your task bead*, recorded as comments during execution.
 
+## Description Quality and File Addressing
+
+### What Makes a Good Description
+
+Every bead description must enable a bot to complete the task cold — no codebase exploration, no guessing. The beads server enforces this with lint warnings emitted to stderr on `new`. A high-quality description:
+
+- Starts with an **imperative verb**: Fix, Add, Update, Refactor, Implement, ...
+- Names at least one **file path** with a recognized extension (.go, .py, .ts, .js, .rs) or path component (/internal/, /cmd/, /src/, /pkg/)
+- Identifies a **precise location**: function name in backticks, or an Acme file address (see below)
+- Wraps all identifiers in **backticks**: `` `lintDescription()` ``, `` `--no-lint` ``, `` `TypeName` ``
+- Includes a **"how" signal**: "following the pattern in X", "same as Y", "mirrors Z"
+- States an **observable acceptance criterion**: "must return ...", "should emit ...", "returns ..."
+- Avoids **vague language**: somehow, maybe, etc., stuff, try to, a bit
+- Avoids **first-person voice**: I need, we want, I'll
+- For descriptions > 150 chars, includes a **cross-reference**: `bd-XXX` or a URL
+
+### File Addressing
+
+When referencing source locations, use **Acme/sam address syntax** — not the common but incorrect hyphen form.
+
+**Correct forms (from `/home/lkn/plan9/plumb/fileaddr`):**
+
+```
+beads.go:123          line 123
+beads.go:123,125      lines 123 to 125  (comma range)
+beads.go:/funcName/   regex search      (pattern ≥ 4 chars)
+beads.go:#4096        character offset  4096
+```
+
+**Never use:**
+
+```
+beads.go:123-125      ✗ hyphen range is invalid in Acme — use comma
+```
+
+The linter warns when it detects the hyphen form. The Conductor cold-completion gate also checks for correct Acme syntax before assigning P1/P2 beads.
+
+### Lint Rules Summary
+
+The server checks descriptions against these rules (warnings go to stderr; bypass with `--no-lint`):
+
+| Rule | Signal checked |
+|------|---------------|
+| File path | `.go`/`.py`/etc. or `/internal/`/`/cmd/`/... |
+| Location | `func()`, Acme address, `L123`, `:123`, `#123` |
+| Minimum length | ≥ 80 characters |
+| Acceptance criterion | should / must / returns / displays / assert / verify / accept / expect |
+| Acme address format | No `file:N-N` hyphen ranges |
+| Imperative start | Not "Need to" / "Should" / "We need" / "The X" |
+| Vague language | No somehow / maybe / etc. / stuff / try to |
+| How signal | following / same as / pattern from / similar to / mirrors |
+| First-person | No I need / I want / we should / we'll |
+| Forbidden phrases | No "fix this" / "update this" / "make it work" |
+| Inline code | Backtick identifier required when file path present |
+| Cross-reference | `bd-XXX` or URL required for descriptions > 150 chars |
+
 ## JSON Output for Programmatic Use
 
 All read endpoints return JSON for easy parsing.
@@ -353,6 +409,13 @@ This protocol applies recursively. If a child has grandchildren, resolve them be
 ### Create bead
 ```bash
 echo "new \"Implement feature\" \"Add new capability\"" | 9p write agent/beads/ctl
+```
+
+The server emits lint warnings to stderr if the description is missing quality signals (file path, function name/line, acceptance criterion, minimum length). Suppress with `--no-lint` or prefix the title with `IDEA:`:
+
+```bash
+# Bypass lint for idea-type or trivial beads
+echo "new \"IDEA: Explore caching\" \"Some rough thoughts\" --no-lint" | 9p write agent/beads/ctl
 ```
 
 ### Create child bead


### PR DESCRIPTION
## Summary

- **Lint check** (`internal/p9/beads.go`): `new` command now warns to stderr when a description is missing a file path, function/line reference, minimum length, or acceptance criterion keyword. Bypass with `--no-lint` or `IDEA:` title prefix.
- **Post-completion write-back** (`~/.claude/skills/beads/SKILL.md`): new convention section with quality ratings (`good` / `missing-location` / `missing-pattern` / `too-vague`) and a matching anti-pattern entry.
- **Taskmaster prompt** (`bot-templates/Taskmaster`): enforces five-field schema (What/Where/How/Accept/Refs), KB query before writing, file path requirement, observable acceptance criteria, and type-specific templates (bug/feature/refactor/idea).
- **Conductor prompt** (`bot-templates/Conductor`): adds five-question cold-completion gate for P1/P2 beads before assignment.

## Test plan

- [ ] `echo "new 'Fix bug' 'short'" | 9p write agent/beads/ctl` emits lint warnings to server stderr
- [ ] `echo "new 'Fix bug' 'short' --no-lint" | 9p write agent/beads/ctl` succeeds silently
- [ ] `echo "new 'IDEA: explore caching' 'some thoughts'" | 9p write agent/beads/ctl` skips lint
- [ ] Description with file path + func name + accept keyword + 80+ chars produces no warnings
- [ ] `go build ./...` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)